### PR TITLE
[Feature] CIが必ず結果を返すように変更する

### DIFF
--- a/.github/workflows/check-pip-dependency.yml
+++ b/.github/workflows/check-pip-dependency.yml
@@ -10,11 +10,14 @@ jobs:
   pip-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: checkout repo
+        uses: actions/checkout@v3
+
       - name: setup python
         uses: actions/setup-python@v2
         with:
           python-version: 3.11.3
+
       - name: pip check
         run: |
           pip install -r requirements.txt

--- a/.github/workflows/check-pip-dependency.yml
+++ b/.github/workflows/check-pip-dependency.yml
@@ -10,6 +10,7 @@ jobs:
   pip-check:
     runs-on: ubuntu-latest
     steps:
+
       - name: checkout repo
         uses: actions/checkout@v3
 
@@ -18,8 +19,16 @@ jobs:
         with:
           python-version: 3.11.3
 
-      - name: pip check
+      - uses: dorny/paths-filter@v2
+        id: changes
+        with:
+          filters: |
+            src:
+              - 'python/gpt-codegen/**'
+
+      # run only if some file in 'src' folder was changed
+      - if: steps.changes.outputs.src == 'true'
         run: |
-          pip install -r requirements.txt
+          pip install -r requirements.txt && pip check
         working-directory: python/gpt-codegen
 

--- a/.github/workflows/check-pip-dependency.yml
+++ b/.github/workflows/check-pip-dependency.yml
@@ -3,8 +3,6 @@ on:
   pull_request:
     branches:
       - main
-    paths:
-      - "python/gpt-codegen/**"
 
 jobs:
   pip-check:


### PR DESCRIPTION
## WHY

`protect branch` と github actions の `on.pull_request.paths` はすこぶる相性が悪かった．というのも，発火しなかった場合は当該PRがマージできないため，どうしようもなかった．これをなんとかしたい．

## WHAT

https://github.com/dorny/paths-filter を導入する